### PR TITLE
Add user switching

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -2,3 +2,5 @@ FROM wodby/drupal-php:5.6
 
 USER root
 RUN apk add --update --no-cache --virtual pdftk
+
+USER www-data

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,3 +1,4 @@
 FROM wodby/drupal-php:5.6
 
+USER root
 RUN apk add --update --no-cache --virtual pdftk

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,3 +1,4 @@
 FROM wodby/drupal-php:7.0
 
+USER root
 RUN apk add --update --no-cache --virtual pdftk

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -2,3 +2,5 @@ FROM wodby/drupal-php:7.0
 
 USER root
 RUN apk add --update --no-cache --virtual pdftk
+
+USER www-data

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -2,3 +2,5 @@ FROM wodby/drupal-php:7.1
 
 USER root
 RUN apk add --update --no-cache --virtual pdftk
+
+USER www-data

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,3 +1,4 @@
 FROM wodby/drupal-php:7.1
 
+USER root
 RUN apk add --update --no-cache --virtual pdftk


### PR DESCRIPTION
After the 3.x update in `wodby/drupal-php` the default user is `www-data` instead of `root`, this prevents to run `apk` without user switching first.